### PR TITLE
Enforce secure Plex endpoints with explicit HTTP override

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,24 @@ Runs as a single Docker container, stores artifacts on a bind-mounted `/data`, a
 Create a `.env` next to your Compose file or inject as container env.
 See `.env.example` for defaults.
 
-| Variable            | Default                    | Notes                                       |
-| ------------------- | -------------------------- | ------------------------------------------- |
-| `PLEX_BASE`         | `http://localhost:32400`   | Your PMS URL                                |
-| `PLEX_TOKEN`        | *(required)*               | Plex auth token                             |
-| `DB_PATH`           | `/data/recommendations.db` | SQLite path                                 |
-| `ART_DIR`           | `/data`                    | Where vector artifacts are stored           |
-| `PULL_INTERVAL_MIN` | `60`                       | Scheduler interval (minutes)                |
-| `DISABLE_AUTOSTART` | `false`                    | Skip auto-pipeline on start (useful in dev) |
-| `LOG_LEVEL`         | `INFO`                     | `DEBUG` for more detail                     |
-| `LOG_FILE`          | `/data/recommenderr.log`   | Rotating log file                           |
+| Variable                        | Default                    | Notes                                                                 |
+| ------------------------------- | -------------------------- | --------------------------------------------------------------------- |
+| `PLEX_BASE`                     | `http://localhost:32400`   | Prefer `https://...` for any non-localhost PMS endpoint              |
+| `PLEX_TOKEN`                    | *(required)*               | Plex auth token                                                       |
+| `ALLOW_INSECURE_PLEX_HTTP`      | `false`                    | Set `true` to explicitly allow non-localhost `http://` with token auth |
+| `DB_PATH`                       | `/data/recommendations.db` | SQLite path                                                           |
+| `ART_DIR`                       | `/data`                    | Where vector artifacts are stored                                     |
+| `PULL_INTERVAL_MIN`             | `60`                       | Scheduler interval (minutes)                                          |
+| `DISABLE_AUTOSTART`             | `false`                    | Skip auto-pipeline on start (useful in dev)                           |
+| `LOG_LEVEL`                     | `INFO`                     | `DEBUG` for more detail                                               |
+| `LOG_FILE`                      | `/data/recommenderr.log`   | Rotating log file                                                     |
+
+### Plex endpoint security expectations
+
+- For remote/non-local Plex servers, configure `PLEX_BASE` with `https://` and a certificate trusted by the container host.
+- Plain `http://` is only intended for loopback/local development (`localhost`, `127.0.0.1`, `::1`).
+- On startup, Recommenderr now hard-fails if `PLEX_BASE` is non-localhost HTTP while `PLEX_TOKEN` is set, unless you explicitly opt in with `ALLOW_INSECURE_PLEX_HTTP=true`.
+- If you must run insecure HTTP on a trusted home LAN segment, set `ALLOW_INSECURE_PLEX_HTTP=true` so the risk is explicit and logged as a warning.
 
 ### Docker runtime user and `/data` permissions
 


### PR DESCRIPTION
### Motivation

- Reduce accidental exposure of `PLEX_TOKEN` by preferring `https://` endpoints for any non-localhost Plex Media Server.
- Make insecure `http://` + token usage explicit and visible instead of silently allowed.
- Provide an explicit opt-in for trusted home-network setups so operators acknowledge the risk.

### Description

- Updated the configuration table in `README.md` to prefer `https://` for non-localhost PMS, added `ALLOW_INSECURE_PLEX_HTTP` to the env vars, and documented certificate/expectations in a new "Plex endpoint security expectations" section.
- Added `ALLOW_INSECURE_PLEX_HTTP` parsing to `app/config.py` and imported `urlparse` to analyze `PLEX_BASE`.
- Implemented `_is_localhost()` and a startup-time validation in `app/config.py` that raises a `RuntimeError` when `PLEX_BASE` is `http://` for a non-localhost host while token auth is enabled, unless `ALLOW_INSECURE_PLEX_HTTP=true` is set.
- When `ALLOW_INSECURE_PLEX_HTTP=true` is present the code emits a clear `WARNING` on startup instead of failing.

### Testing

- Ran `python -m compileall app/config.py app/plex.py` and the files compiled successfully.
- Verified `RuntimeError` by importing with `PLEX_TOKEN=t PLEX_BASE=http://192.168.1.2:32400` which produced the expected failure.
- Verified opt-in behavior by importing with `PLEX_TOKEN=t PLEX_BASE=http://192.168.1.2:32400 ALLOW_INSECURE_PLEX_HTTP=true` which printed the `WARNING` and allowed import to succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04f1263c0832f9d8a8b6212f46320)