### PR TITLE
Remove emission of transient X-Plex-Token poster URLs and sanitize token handling

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -81,14 +81,13 @@ def recommend(
     k_opt: int = typer.Option(None, "--k", "-k", min=1, help="How many recommendations (option)"),
     output: str = typer.Option("text", "--output", "-o", help="text or json"),
     explain: bool = typer.Option(False, "--explain", help="Show feature-group contributions"),
-    include_auth_token: bool = typer.Option(False, "--include-auth-token", help="Emit transient signed poster URLs with X-Plex-Token"),
 ):
     """Print top-K recommendations for a user."""
     ensure_schema()
     k = k_opt if k_opt is not None else k_arg
 
     log.info("Recommend requested: query=%r k=%d fmt=%s explain=%s", username, k, output, explain)
-    recs = recommend_for_username(username, k=k, explain=explain, include_auth_token=include_auth_token)
+    recs = recommend_for_username(username, k=k, explain=explain)
 
     if not recs:
         log.warning("No recs available for query=%r", username)

--- a/app/plex.py
+++ b/app/plex.py
@@ -14,7 +14,7 @@ def strip_plex_token(value: str | None) -> str | None:
     parts = urlsplit(value)
     if not parts.query:
         return value
-    cleaned = [(k, v) for k, v in parse_qsl(parts.query, keep_blank_values=True) if k != "X-Plex-Token"]
+    cleaned = [(k, v) for k, v in parse_qsl(parts.query, keep_blank_values=True) if k.lower() != "x-plex-token"]
     query = urlencode(cleaned, doseq=True)
     return urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))
 

--- a/app/recommendations.py
+++ b/app/recommendations.py
@@ -4,19 +4,19 @@ import pandas as pd
 import scipy.sparse as sp
 from .db import engine
 from .features import load_artifacts
-from .config import PLEX_BASE, PLEX_TOKEN, REC_COLLECTION_BOOST, REC_COLLECTION_LOOKBACK
+from .config import PLEX_BASE, REC_COLLECTION_BOOST, REC_COLLECTION_LOOKBACK
+from .plex import strip_plex_token
 
 log = logging.getLogger(__name__)
 
 
-def _build_poster_url(poster_path: str | None, include_auth_token: bool = False) -> str | None:
+def _build_poster_url(poster_path: str | None) -> str | None:
     if not poster_path:
         return None
-    base = f"{PLEX_BASE}{poster_path}"
-    if include_auth_token and PLEX_TOKEN:
-        joiner = "&" if "?" in poster_path else "?"
-        return f"{base}{joiner}X-Plex-Token={PLEX_TOKEN}"
-    return base
+    cleaned = strip_plex_token(str(poster_path))
+    if not cleaned:
+        return None
+    return f"{PLEX_BASE}{cleaned}"
 
 def _get_user_row(query: str):
     with engine().begin() as con:
@@ -195,7 +195,7 @@ def _recent_user_collections(user_id: str, lookback: int) -> set[str]:
     return cols
 
 """Return top-K recommendations for a user."""
-def recommend_for_username(user_query: str, k: int = 10, explain: bool = False, include_auth_token: bool = False):
+def recommend_for_username(user_query: str, k: int = 10, explain: bool = False):
     try:
         vecs, X, id_index = load_artifacts()
     except Exception as e:
@@ -321,7 +321,7 @@ def recommend_for_username(user_query: str, k: int = 10, explain: bool = False, 
             "year": r.year,
             "genres": (r.genres_csv or ""),
             "collections": (r.collections_csv or ""),
-            "poster": _build_poster_url(r.poster_path, include_auth_token=include_auth_token),
+            "poster": _build_poster_url(r.poster_path),
             "relevancy": match_pct,
             "score": round(sc_map[r.item_id], 4)
         }


### PR DESCRIPTION
### Motivation
- Simplify poster URL handling by removing logic that emitted transient signed poster URLs with `X-Plex-Token` and ensure Plex token fragments are sanitized consistently. 
- Avoid leaking or re-attaching `X-Plex-Token` to URLs produced by the recommender and make token-stripping case-insensitive. 

### Description
- Removed the `--include-auth-token` CLI option from the `recommend` command and stopped passing `include_auth_token` into `recommend_for_username` from `app/cli.py`. 
- Updated `recommend_for_username` signature in `app/recommendations.py` to remove the `include_auth_token` parameter and removed use of `PLEX_TOKEN` when building poster URLs. 
- Reworked `_build_poster_url` to call `strip_plex_token` and always return a cleaned `PLEX_BASE`-prefixed URL instead of appending `X-Plex-Token`. 
- Made `strip_plex_token` in `app/plex.py` perform a case-insensitive match for the `X-Plex-Token` query parameter so tokens in different casings are removed. 

### Testing
- Ran the unit test suite with `pytest -q` and the tests completed successfully. 
- Performed a recommendation smoke test by invoking the `recommend` command and verified poster URLs no longer include `X-Plex-Token`. 
- Verified import and linting checks to ensure no unresolved references after removing `PLEX_TOKEN` usage in the recommender.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04d65c3ac832f92d2ae9301f09182)